### PR TITLE
Add functionality for IP range filter and virtual network rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,13 @@ resource "azurerm_cosmosdb_account" "db" {
     max_interval_in_seconds = try(var.cosmosdb.consistency_policy.max_interval_in_seconds, 300)
     max_staleness_prefix    = try(var.cosmosdb.consistency_policy.max_staleness_prefix, 100000)
   }
+
+  ip_range_filter = var.cosmosdb.ip_range_filter
+
+  virtual_network_rule {
+    id                                   = var.cosmosdb.subscription_id
+    ignore_missing_vnet_service_endpoint = try(var.cosmosdb.enable.ignore_missing_vnet_service_endpoint, false)
+  }
 }
 
 # mongo databases

--- a/main.tf
+++ b/main.tf
@@ -46,10 +46,10 @@ resource "azurerm_cosmosdb_account" "db" {
   ip_range_filter = var.cosmosdb.ip_range_filter
 
   dynamic "virtual_network_rule" {
-    for_each = try(var.cosmosdb.virtual_network_rules, {})
+    for_each = try(var.cosmosdb.virtual_network_rule, {})
     content {
-      id                                   = each.value.id
-      ignore_missing_vnet_service_endpoint = each.value.ignore_missing_vnet_service_endpoint
+      id                                   = virtual_network_rule.value.id
+      ignore_missing_vnet_service_endpoint = virtual_network_rule.value.ignore_missing_vnet_service_endpoint
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_cosmosdb_account" "db" {
   ip_range_filter = var.cosmosdb.ip_range_filter
 
   dynamic "virtual_network_rule" {
-    for_each = try(var.cosmosdb.virtual_network_rules, [])
+    for_each = try(var.cosmosdb.virtual_network_rules, {})
     content {
       id                                   = each.value.id
       ignore_missing_vnet_service_endpoint = each.value.ignore_missing_vnet_service_endpoint

--- a/main.tf
+++ b/main.tf
@@ -48,8 +48,8 @@ resource "azurerm_cosmosdb_account" "db" {
   dynamic "virtual_network_rule" {
     for_each = try(var.cosmosdb.virtual_network_rules, [])
     content {
-      id                                   = virtual_network_rules.value.id
-      ignore_missing_vnet_service_endpoint = virtual_network_rules.value.ignore_missing_vnet_service_endpoint
+      id                                   = each.value.id
+      ignore_missing_vnet_service_endpoint = each.value.ignore_missing_vnet_service_endpoint
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_cosmosdb_account" "db" {
 
   ip_range_filter = var.cosmosdb.ip_range_filter
 
-  dynamic "virtual_network_rules" {
+  dynamic "virtual_network_rule" {
     for_each = try(var.cosmosdb.virtual_network_rules, [])
     content {
       id                                   = virtual_network_rules.value.id

--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,8 @@ resource "azurerm_cosmosdb_account" "db" {
   ip_range_filter = var.cosmosdb.ip_range_filter
 
   virtual_network_rule {
-    id                                   = var.cosmosdb.subscription_id
-    ignore_missing_vnet_service_endpoint = try(var.cosmosdb.enable.ignore_missing_vnet_service_endpoint, false)
+    id                                   = try(var.cosmosdb.virtual_network_rule.id, "")
+    ignore_missing_vnet_service_endpoint = try(var.cosmosdb.virtual_network_rule.ignore_missing_vnet_service_endpoint, false)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -45,11 +45,11 @@ resource "azurerm_cosmosdb_account" "db" {
 
   ip_range_filter = var.cosmosdb.ip_range_filter
 
-  dynamic "virtual_network_rule" {
-    for_each = try(var.cosmosdb.virtual_network_rule, [])
+  dynamic "virtual_network_rules" {
+    for_each = try(var.cosmosdb.virtual_network_rules, [])
     content {
-      id                                   = try(var.cosmosdb.virtual_network_rule.id, "")
-      ignore_missing_vnet_service_endpoint = try(var.cosmosdb.virtual_network_rule.ignore_missing_vnet_service_endpoint, false)
+      id                                   = virtual_network_rules.value.id
+      ignore_missing_vnet_service_endpoint = virtual_network_rules.value.ignore_missing_vnet_service_endpoint
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -45,9 +45,12 @@ resource "azurerm_cosmosdb_account" "db" {
 
   ip_range_filter = var.cosmosdb.ip_range_filter
 
-  virtual_network_rule {
-    id                                   = try(var.cosmosdb.virtual_network_rule.id, "")
-    ignore_missing_vnet_service_endpoint = try(var.cosmosdb.virtual_network_rule.ignore_missing_vnet_service_endpoint, false)
+  dynamic "virtual_network_rule" {
+    for_each = try(var.cosmosdb.virtual_network_rule, [])
+    content {
+      id                                   = try(var.cosmosdb.virtual_network_rule.id, "")
+      ignore_missing_vnet_service_endpoint = try(var.cosmosdb.virtual_network_rule.ignore_missing_vnet_service_endpoint, false)
+    }
   }
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,15 +1,15 @@
-terraform {
-  required_version = "~> 1.0"
+# terraform {
+#   required_version = "~> 1.0"
 
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.61"
-    }
+#   required_providers {
+#     azurerm = {
+#       source  = "hashicorp/azurerm"
+#       version = "~> 3.61"
+#     }
 
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5.1"
-    }
-  }
-}
+#     random = {
+#       source  = "hashicorp/random"
+#       version = "~> 3.5.1"
+#     }
+#   }
+# }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,15 +1,15 @@
-# terraform {
-#   required_version = "~> 1.0"
+terraform {
+  required_version = "~> 1.0"
 
-#   required_providers {
-#     azurerm = {
-#       source  = "hashicorp/azurerm"
-#       version = "~> 3.61"
-#     }
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.61"
+    }
 
-#     random = {
-#       source  = "hashicorp/random"
-#       version = "~> 3.5.1"
-#     }
-#   }
-# }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.1"
+    }
+  }
+}


### PR DESCRIPTION
Incoroprated the following two attributes to the terraform module
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#ip_range_filter

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#virtual_network_rule

Virtual network rule is a dynamic object, of which multiple can be added, if no virtual network rules are created the module will default to an empty {} object.

ip_range_filter is just an additional string
The separate IP addresses are added using commas, which is interpreted by azure