### PR TITLE
fix: bounced all modules to latest version in usages and removed unneeded outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_cosmosdb_sql_database.sqldb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_database) | resource |
 | [azurerm_cosmosdb_table.tables](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_table) | resource |
 | [azurerm_user_assigned_identity.identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -76,7 +75,6 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | <a name="output_mongodb_collection"></a> [mongodb\_collection](#output\_mongodb\_collection) | n/a |
 | <a name="output_sql_container"></a> [sql\_container](#output\_sql\_container) | n/a |
 | <a name="output_sqldb"></a> [sqldb](#output\_sqldb) | n/a |
-| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | n/a |
 | <a name="output_tables"></a> [tables](#output\_tables) | n/a |
 <!-- END_TF_DOCS -->
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,8 +1,0 @@
-output "account" {
-  value     = module.cosmosdb.account
-  sensitive = true
-}
-
-output "subscription_id" {
-  value = module.cosmosdb.subscription_id
-}

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/mongodb/main.tf
+++ b/examples/mongodb/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -22,7 +22,7 @@ module "cosmosdb" {
   version = "~> 2.0"
 
   account = {
-    name           = module.naming.cosmosdb_account.name
+    name           = module.naming.cosmosdb_account.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
     kind           = "MongoDB"

--- a/examples/network-rules/main.tf
+++ b/examples/network-rules/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -19,7 +19,7 @@ module "rg" {
 
 module "network" {
   source  = "cloudnationhq/vnet/azure"
-  version = "~> 4.0"
+  version = "~> 8.0"
 
   naming = local.naming
 
@@ -27,12 +27,12 @@ module "network" {
     name           = module.naming.virtual_network.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    cidr           = ["10.19.0.0/16"]
+    address_space  = ["10.19.0.0/16"]
 
     subnets = {
       sn1 = {
-        cidr = ["10.19.1.0/24"]
-        endpoints = [
+        address_prefixes = ["10.19.1.0/24"]
+        service_endpoints = [
           "Microsoft.AzureCosmosDB",
         ]
       }

--- a/examples/private-endpoint/endpoints.tf
+++ b/examples/private-endpoint/endpoints.tf
@@ -4,7 +4,7 @@ locals {
       name                           = module.naming.private_endpoint.name
       subnet_id                      = module.network.subnets.sn1.id
       private_connection_resource_id = module.cosmosdb.account.id
-      private_dns_zone_ids           = [module.private_dns.zones.mongo.id]
+      private_dns_zone_ids           = [module.private_dns.private_zones.mongo.id]
       subresource_names              = ["MongoDB"]
     }
   }

--- a/examples/private-endpoint/main.tf
+++ b/examples/private-endpoint/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -19,7 +19,7 @@ module "rg" {
 
 module "network" {
   source  = "cloudnationhq/vnet/azure"
-  version = "~> 4.0"
+  version = "~> 8.0"
 
   naming = local.naming
 
@@ -27,12 +27,12 @@ module "network" {
     name           = module.naming.virtual_network.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    cidr           = ["10.19.0.0/16"]
+    address_space  = ["10.19.0.0/16"]
 
     subnets = {
       sn1 = {
-        nsg  = {}
-        cidr = ["10.19.1.0/24"]
+        network_security_group = {}
+        address_prefixes       = ["10.19.1.0/24"]
       }
     }
   }
@@ -43,7 +43,7 @@ module "cosmosdb" {
   version = "~> 2.0"
 
   account = {
-    name           = module.naming.cosmosdb_account.name
+    name           = module.naming.cosmosdb_account.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
     kind           = "MongoDB"
@@ -60,17 +60,19 @@ module "cosmosdb" {
 
 module "private_dns" {
   source  = "cloudnationhq/pdns/azure"
-  version = "~> 1.0"
+  version = "~> 3.0"
 
   resource_group = module.rg.groups.demo.name
 
   zones = {
-    mongo = {
-      name = "privatelink.mongo.cosmos.azure.com"
-      virtual_network_links = {
-        link1 = {
-          virtual_network_id   = module.network.vnet.id
-          registration_enabled = true
+    private = {
+      mongo = {
+        name = "privatelink.mongo.cosmos.azure.com"
+        virtual_network_links = {
+          link1 = {
+            virtual_network_id   = module.network.vnet.id
+            registration_enabled = true
+          }
         }
       }
     }

--- a/examples/sqldb/main.tf
+++ b/examples/sqldb/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "prd"]
 }
@@ -22,7 +22,7 @@ module "cosmosdb" {
   version = "~> 2.0"
 
   account = {
-    name           = module.naming.cosmosdb_account.name
+    name           = module.naming.cosmosdb_account.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
     kind           = "GlobalDocumentDB"

--- a/examples/tables/main.tf
+++ b/examples/tables/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -22,7 +22,7 @@ module "cosmosdb" {
   version = "~> 2.0"
 
   account = {
-    name           = module.naming.cosmosdb_account.name
+    name           = module.naming.cosmosdb_account.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
     kind           = "GlobalDocumentDB"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-data "azurerm_subscription" "current" {}
-
 # cosmosdb account
 resource "azurerm_cosmosdb_account" "db" {
   name                       = var.account.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,10 +2,6 @@ output "account" {
   value = azurerm_cosmosdb_account.db
 }
 
-output "subscription_id" {
-  value = data.azurerm_subscription.current.subscription_id
-}
-
 output "mongodb" {
   value = azurerm_cosmosdb_mongo_database.mongodb
 }


### PR DESCRIPTION
## Description

This PR increments all modules in usages to the latest. All deployment tests will succeed now..
Also the subscription_id output is removed, as it is not needed anymore.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)