### PR TITLE
fix: make throughput sql containers and databases optional and set a default for partition key version

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For more information, please see our contribution [guidelines](./CONTRIBUTING.md
 
 MIT Licensed. See [LICENSE](./LICENSE) for full details.
 
-## Reference
+## References
 
 - [Documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/)
 - [Rest Api](https://learn.microsoft.com/en-us/rest/api/cosmos-db/)

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ resource "azurerm_cosmosdb_sql_database" "sqldb" {
   name                = try(each.value.name, "sql-${each.key}")
   account_name        = azurerm_cosmosdb_account.db.name
   resource_group_name = azurerm_cosmosdb_account.db.resource_group_name
-  throughput          = each.value.throughput
+  throughput          = try(each.value.throughput, null)
 }
 
 # sql containers
@@ -243,7 +243,7 @@ resource "azurerm_cosmosdb_sql_container" "sqlc" {
         db_key              = db_key
         container_key       = container_key
         name                = try(container.name, "${db_key}-${container_key}")
-        throughput          = container.throughput
+        throughput          = try(container.throughput, null)
         indexing_mode       = container.index_policy.indexing_mode
         included_paths      = try(container.index_policy.included_paths, [])
         excluded_paths      = try(container.index_policy.excluded_paths, [])
@@ -261,7 +261,7 @@ resource "azurerm_cosmosdb_sql_container" "sqlc" {
   database_name         = azurerm_cosmosdb_sql_database.sqldb[each.value.db_key].name
   partition_key_paths   = each.value.partition_key_paths
   partition_key_kind    = each.value.partition_key_kind
-  partition_key_version = 1
+  partition_key_version = try(each.value.partition_key_version, 1)
   throughput            = each.value.throughput
   default_ttl           = each.value.default_ttl
 


### PR DESCRIPTION
## Description

This PR makes throughput sql containers and databases optional and sets a default for partition key version

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)